### PR TITLE
Event Key prop warning fix

### DIFF
--- a/src/components/Participant.jsx
+++ b/src/components/Participant.jsx
@@ -50,7 +50,7 @@ const Participant = ({
     }
   };
   return (
-    <Card eventKey={index} className="!rounded-none border-t-0">
+    <Card className="!rounded-none border-t-0">
       <Card.Header
         className={
           "flex items-center focus:!ring-0 focus:!bg-hackathon-green-100 " +


### PR DESCRIPTION
Reason for warning:
In line 53 of Participant.jsx, the Card bootstrap component should not take in the eventKey prop.