### PR TITLE
fixed judge type colors

### DIFF
--- a/src/components/Admin/Tag.jsx
+++ b/src/components/Admin/Tag.jsx
@@ -37,8 +37,8 @@ const colors = {
     text: "text-hackathon-judge-student-text",
   },
   industry: {
-    background: "bg-hackathon-judge-student-bg",
-    text: "text-hackathon-judge-student-text",
+    background: "bg-hackathon-judge-industry-bg",
+    text: "text-hackathon-judge-industry-text",
   },
 };
 


### PR DESCRIPTION
judge type colors used to look like this: 

![image](https://github.com/acm-ucr/hackathon-website/assets/75003679/c6ab9dc9-aece-4558-9b10-213205dd3ecf)

now it looks like this: (industry and student were the same color originally)
<img width="272" alt="image" src="https://github.com/acm-ucr/hackathon-website/assets/75003679/0349d40e-4b38-443e-927b-05ab47a3e1d5">
