### PR TITLE
changed sentence of the max files to files instead of objects

### DIFF
--- a/src/components/Admin/Upload.jsx
+++ b/src/components/Admin/Upload.jsx
@@ -16,7 +16,7 @@ const Upload = ({ text, setObjects, objects, size, types }) => {
   const handleInput = (e) => {
     setUploading(true);
     if (objects.files.length + e.target.files.length > 5) {
-      toast("❌ Exceeds 5 objects!");
+      toast("❌ Exceeds 5 files!");
       setUploading(false);
       return;
     }


### PR DESCRIPTION
I changed the error message in the messenger section from "exceeds 5 objects" to "exceeds 5 files".