### PR TITLE
added filter to links in teams api

### DIFF
--- a/src/app/api/teams/route.js
+++ b/src/app/api/teams/route.js
@@ -31,9 +31,11 @@ export async function GET() {
       const formattedNames = members.map((member) => member.name);
       const formattedEmails = members.map((member) => member.email);
       const formattedUids = members.map((member) => member.uid);
-      const formattedLinks = Object.entries(links).map(([key, value]) => {
-        return { name: key, link: value };
-      });
+      const formattedLinks = Object.entries(links)
+        .filter(([key, value]) => value !== "")
+        .map(([key, value]) => {
+          return { name: key, link: value };
+        });
 
       output.push({
         links: formattedLinks,


### PR DESCRIPTION
<img width="920" alt="image" src="https://github.com/acm-ucr/hackathon-website/assets/54488379/bb9f0190-8925-4b4a-96df-4d20b00ea5a7">

* Adds filter to `formattedLinks` in `teams` API route to filter out all empty links
* Closes #740 