### PR TITLE
changed team api to save discord instead of email

### DIFF
--- a/src/app/api/team/route.js
+++ b/src/app/api/team/route.js
@@ -6,8 +6,7 @@ import { AUTH } from "@/data/dynamic/user/Team";
 
 export async function POST() {
   const res = NextResponse;
-  const { auth, message, user } = await authenticate(AUTH.POST); // this user is taken from the session
-  console.log(user);
+  const { auth, message, user } = await authenticate(AUTH.POST);
 
   if (auth !== 200) {
     return res.json(

--- a/src/app/api/team/route.js
+++ b/src/app/api/team/route.js
@@ -6,7 +6,8 @@ import { AUTH } from "@/data/dynamic/user/Team";
 
 export async function POST() {
   const res = NextResponse;
-  const { auth, message, user } = await authenticate(AUTH.POST);
+  const { auth, message, user } = await authenticate(AUTH.POST); // this user is taken from the session
+  console.log(user);
 
   if (auth !== 200) {
     return res.json(
@@ -22,7 +23,7 @@ export async function POST() {
         devpost: "",
         figma: "",
       },
-      members: [{ email: user.email, name: user.name, uid: user.id }],
+      members: [{ discord: user.discord, name: user.name, uid: user.id }],
       status: 0,
     };
     const docRef = await addDoc(collection(db, "teams"), team);

--- a/src/app/api/teams/route.js
+++ b/src/app/api/teams/route.js
@@ -29,7 +29,7 @@ export async function GET() {
       const { links, status, members } = doc.data();
 
       const formattedNames = members.map((member) => member.name);
-      const formattedEmails = members.map((member) => member.email);
+      const formattedDiscords = members.map((member) => member.discord);
       const formattedUids = members.map((member) => member.uid);
       const formattedLinks = Object.entries(links)
         .filter(([key, value]) => value !== "")
@@ -40,7 +40,7 @@ export async function GET() {
       output.push({
         links: formattedLinks,
         members: formattedNames,
-        emails: formattedEmails,
+        discords: formattedDiscords,
         uids: formattedUids,
         status,
         uid: doc.id,

--- a/src/data/dynamic/admin/Teams.js
+++ b/src/data/dynamic/admin/Teams.js
@@ -26,7 +26,7 @@ export const TAGS = [
 export const HEADERS = [
   { text: "name", size: "w-2/12", icon: true, sort: "off", symbol: "winner" },
   { text: "members", size: "w-2/12", icon: false, sort: "off" },
-  { text: "emails", size: "w-3/12", icon: false, sort: "off" },
+  { text: "discords", size: "w-3/12", icon: false, sort: "off" },
   { text: "links", size: "w-3/12", icon: false, sort: "off" },
   {
     text: "status",


### PR DESCRIPTION
![image](https://github.com/acm-ucr/hackathon-website/assets/54488379/0822e9ed-0210-4192-81d7-53d923a58584)

* team api now saves the discord instead of email
* teams dashboard now displays discord with consistent UI
* closes #895 