### PR TITLE
Fuyuki/RadioTesting

### DIFF
--- a/cypress/component/Radio.cy.jsx
+++ b/cypress/component/Radio.cy.jsx
@@ -1,0 +1,108 @@
+import Radio from "@/components/dynamic/Radio";
+import { GENDERS } from "@/data/dynamic/form/Information";
+import { useState } from "react";
+
+describe("Radio", () => {
+  it("renders text", () => {
+    const Parent = () => {
+      const [user, setUser] = useState({ name: "" });
+      return (
+        <Radio
+          text="Gender"
+          options={GENDERS}
+          field="gender"
+          user={user}
+          setUser={setUser}
+          editable={true}
+        />
+      );
+    };
+
+    cy.mount(<Parent />);
+
+    // radio container exists
+    cy.get("[data-cy=radio-gender]").should("exist");
+
+    // Has text
+    cy.get("[data-cy=radio-Female]").should("have.text", GENDERS[0]);
+
+    cy.get("[data-cy=radio-Male]").should("have.text", GENDERS[1]);
+
+    cy.get("[data-cy=radio-Transgender]").should("have.text", GENDERS[2]);
+
+    cy.get("[data-cy=radio-Nonbinary]").should("have.text", GENDERS[3]);
+  });
+
+  it("selects options when editable", () => {
+    const Parent = () => {
+      const [user, setUser] = useState({ name: "" });
+      return (
+        <Radio
+          text="Gender"
+          options={GENDERS}
+          field="gender"
+          user={user}
+          setUser={setUser}
+          editable={true}
+        />
+      );
+    };
+
+    cy.mount(<Parent />);
+
+    cy.get("[data-cy=radio-button-Female]").click();
+
+    // Tests if Female button is clicked
+    cy.get("[data-cy=radio-button-Female]").should(
+      "have.css",
+      "background-color",
+      "rgb(87, 204, 153)"
+    );
+
+    // Tests if Male button is not clicked
+    cy.get("[data-cy=radio-button-Male]").should(
+      "have.css",
+      "background-color",
+      "rgba(0, 0, 0, 0)"
+    );
+
+    // Tests if Male button is clicked
+    cy.get("[data-cy=radio-button-Male]").click();
+    cy.get("[data-cy=radio-button-Male]").should(
+      "have.css",
+      "background-color",
+      "rgb(87, 204, 153)"
+    );
+
+    // Tests if Female button is unselected
+    cy.get("[data-cy=radio-button-Female]").should(
+      "have.css",
+      "background-color",
+      "rgba(0, 0, 0, 0)"
+    );
+  });
+
+  it("cannot select options when uneditable", () => {
+    const Parent = () => {
+      const [user, setUser] = useState({ name: "" });
+      return (
+        <Radio
+          text="Gender"
+          options={GENDERS}
+          field="gender"
+          user={user}
+          setUser={setUser}
+          editable={false}
+        />
+      );
+    };
+
+    cy.mount(<Parent />);
+
+    // Cannot find it when editable is set to false
+    // Only the text is showing up. No buttons
+    // Expected behavior?
+    cy.get("[data-cy=radio-button-Female]").should("not.exist");
+    cy.get("[data-cy=radio-button-Male]").should("not.exist");
+  });
+});

--- a/src/components/dynamic/Radio.jsx
+++ b/src/components/dynamic/Radio.jsx
@@ -12,22 +12,28 @@ const Radio = ({
   };
 
   return (
-    <div className="flex flex-col">
+    <div data-cy={`radio-${field}`} className="flex flex-col">
       <p className="mb-1 font-semibold">
         {text}
         {required && <span className="text-hackathon-green-300">*</span>}
       </p>
-      {!editable && <div className="pl-3">{user[field]}</div>}
+      {!editable && (
+        <div data-cy={`radio-${field}-default`} className="pl-3">
+          {user[field]}
+        </div>
+      )}
       {editable && (
         <div className="grid grid-cols-2 md:grid-cols-3 w-full">
           {options.map((option, index) => (
             <div
+              data-cy={`radio-${option}`}
               className="flex items-center whitespace-nowrap hover:cursor-pointer"
               key={index}
               onClick={() => handleClick(option)}
             >
               <div className="rounded-full w-4 border-black border aspect-square bg-transparent p-0.5 mr-1">
                 <div
+                  data-cy={`radio-button-${option}`}
                   className={`rounded-full w-full aspect-square duration-100 ${
                     option === user[field]
                       ? "bg-hackathon-green-300"


### PR DESCRIPTION
False:
![Screenshot 2024-01-03 065837](https://github.com/acm-ucr/hackathon-website/assets/120443522/3c76b0a1-d1f6-48ad-bd1d-cf6111a300df)

True:
![Screenshot 2024-01-03 070608](https://github.com/acm-ucr/hackathon-website/assets/120443522/3e2ae327-c37d-4912-b7d2-9fc90539df3b)


When editable is set to true, the buttons appear and change colors when clicked.
When editable is set to false, the buttons no longer appear and only the text is left.