### PR TITLE
Consolidated Toaster into Singular Component

### DIFF
--- a/src/utils/toaster.js
+++ b/src/utils/toaster.js
@@ -5,35 +5,32 @@ import { FaCheckCircle } from "react-icons/fa";
 const toaster = (message, type) => {
   switch (type) {
     case "success":
-      toast.custom(
-        <div className="flex items-center justify-center bg-white pl-2 pr-5 md:pr-6 py-4 w-4/12 md:w-2/12 shadow-md rounded">
-          <FaCheckCircle className=" text-green-500" />
-          <div className="inline ps-4 text-sm font-normal text-black">
-            {message}
-          </div>
-        </div>
-      );
+      toast.custom(consolidateToaster(message, type));
       break;
     case "error":
-      toast.custom(
-        <div className="flex items-center justify-center bg-white pl-2 pr-5 md:pr-6 py-4 w-4/12 md:w-2/12 shadow-md rounded">
-          <MdError className=" text-red-500" size="35px" />
-          <div className="inline ps-4 text-sm font-normal text-black">
-            {message}
-          </div>
-        </div>
-      );
+      toast.custom(consolidateToaster(message, type));
       break;
     default:
-      toast.custom(
-        <div className="flex items-center justify-center bg-white pl-2 pr-5 md:pr-6 py-4 w-4/12 md:w-2/12 shadow-md rounded">
-          <MdError className=" text-red-500" size="35px" />
-          <div className="inline ps-4 text-sm font-normal text-black">
-            {message}
-          </div>
-        </div>
-      );
+      toast.custom(consolidateToaster(message, type));
+      break;
   }
+};
+
+const consolidateToaster = (message, type) => {
+  const icon =
+    type === "success" ? (
+      <FaCheckCircle className="text-green-500" size="35px" />
+    ) : (
+      <MdError className="text-red-500" size="35px" />
+    );
+  return (
+    <div className="flex items-center justify-center bg-white pl-2 pr-5 md:pr-6 py-4 w-4/12 md:w-2/12 shadow-md rounded">
+      {icon}
+      <div className="inline ps-4 text-sm font-normal text-black">
+        {message}
+      </div>
+    </div>
+  );
 };
 
 export default toaster;

--- a/src/utils/toaster.js
+++ b/src/utils/toaster.js
@@ -3,29 +3,14 @@ import { MdError } from "react-icons/md";
 import { FaCheckCircle } from "react-icons/fa";
 
 const toaster = (message, type) => {
-  switch (type) {
-    case "success":
-      toast.custom(consolidateToaster(message, type));
-      break;
-    case "error":
-      toast.custom(consolidateToaster(message, type));
-      break;
-    default:
-      toast.custom(consolidateToaster(message, type));
-      break;
-  }
-};
+  const iconMapping = {
+    success: <FaCheckCircle className="text-green-500" size="35px" />,
+    error: <MdError className="text-red-500" size="35px" />,
+  };
 
-const consolidateToaster = (message, type) => {
-  const icon =
-    type === "success" ? (
-      <FaCheckCircle className="text-green-500" size="35px" />
-    ) : (
-      <MdError className="text-red-500" size="35px" />
-    );
-  return (
+  return toast.custom(
     <div className="flex items-center justify-center bg-white pl-2 pr-5 md:pr-6 py-4 w-4/12 md:w-2/12 shadow-md rounded">
-      {icon}
+      {iconMapping[type] || <MdError className="text-red-500" size="35px" />}
       <div className="inline ps-4 text-sm font-normal text-black">
         {message}
       </div>

--- a/src/utils/toaster.js
+++ b/src/utils/toaster.js
@@ -3,14 +3,14 @@ import { MdError } from "react-icons/md";
 import { FaCheckCircle } from "react-icons/fa";
 
 const toaster = (message, type) => {
-  const iconMapping = {
+  const icons = {
     success: <FaCheckCircle className="text-green-500" size="35px" />,
     error: <MdError className="text-red-500" size="35px" />,
   };
 
   return toast.custom(
     <div className="flex items-center justify-center bg-white pl-2 pr-5 md:pr-6 py-4 w-4/12 md:w-2/12 shadow-md rounded">
-      {iconMapping[type] || <MdError className="text-red-500" size="35px" />}
+      {icons[type]}
       <div className="inline ps-4 text-sm font-normal text-black">
         {message}
       </div>


### PR DESCRIPTION
Given that there is a lot of similarity between between each type of toast, I condensed it into a singular component that checks which status toaster receives. I just created a mapping and instead of reusing html code I used the mappings to assign icons to the different type props.

```javascript
const toaster = (message, type) => {
  const iconMapping = {
    success: <FaCheckCircle className="text-green-500" size="35px" />,
    error: <MdError className="text-red-500" size="35px" />,
  };

  return toast.custom(
    <div className="flex items-center justify-center bg-white pl-2 pr-5 md:pr-6 py-4 w-4/12 md:w-2/12 shadow-md rounded">
      {iconMapping[type] || <MdError className="text-red-500" size="35px" />}
      <div className="inline ps-4 text-sm font-normal text-black">
        {message}
      </div>
    </div>
  );
};
``` 