### PR TITLE
Fixed Weekly Calendar Styling Issues

### DIFF
--- a/src/components/dynamic/admin/services/calendar/Events.jsx
+++ b/src/components/dynamic/admin/services/calendar/Events.jsx
@@ -78,6 +78,10 @@ const CalendarEvents = () => {
           localizer={mLocalizer}
           defaultView="month"
           views={["month", "week"]}
+          formats={{
+            eventTimeRangeFormat: ({ start }) =>
+              mLocalizer.format(start, "hh:mm A\n"),
+          }}
           onNavigate={(newDate) => setDate(newDate)}
           onView={(newView) => setView(newView)}
           components={{
@@ -87,7 +91,12 @@ const CalendarEvents = () => {
             ),
           }}
           eventPropGetter={(event) => {
-            return { className: event.color };
+            return {
+              style: {
+                border: "0px",
+              },
+              className: event.color,
+            };
           }}
           dayPropGetter={(event) => {
             const bg =


### PR DESCRIPTION
Using calendars formats component I made it to were the start time is only showed. In addition, I made the descriptions start on a new line if the event is smaller. Border colors have also been removed from the weekly events.

```javascript
**formats={{
  eventTimeRangeFormat: ({ start }) =>
    mLocalizer.format(start, "hh:mm A\n"),
}}**
onNavigate={(newDate) => setDate(newDate)}
onView={(newView) => setView(newView)}
**components={{
  event: (props) => <Event {...props} view={view} />,
  toolbar: (props) => (
    <Toolbar {...props} events={events} setEvents={setEvents} />
  ),
}}**
eventPropGetter={(event) => {
  return {
    style: {
      border: "0px",
    },
    className: event.color,
  };
}}
```