### PR TITLE
Changed dashboard link from "panels" to "panelists"

### DIFF
--- a/src/data/dynamic/Navigation.js
+++ b/src/data/dynamic/Navigation.js
@@ -73,8 +73,8 @@ export const TABS = {
           icon: <GoSponsorTiers className={iconStyle} />,
         },
         {
-          name: "panels",
-          link: "/admin/panels",
+          name: "panelists",
+          link: "/admin/panelists",
           icon: <IoIosPeople className={iconStyle} />,
         },
         {


### PR DESCRIPTION
![image](https://github.com/acm-ucr/hackathon-website/assets/102492968/25718437-7cc8-4f3c-aa95-37521a3c1d52)
Changed link name and directory to panelists