### PR TITLE
Added opacity change to sort icons for table component on hover

### DIFF
--- a/src/components/dynamic/admin/dashboards/dashboard/Table.jsx
+++ b/src/components/dynamic/admin/dashboards/dashboard/Table.jsx
@@ -41,7 +41,7 @@ const Table = ({
                     {flexRender(column.columnDef.header, getContext())}
                     {column.getCanSort() && (
                       <FaArrowRightArrowLeft
-                        className={`mx-2 rotate-90 hover:cursor-pointer text-hackathon-gray-200 ${
+                        className={`mx-2 rotate-90 hover:cursor-pointer hover:opacity-50 text-hackathon-gray-200 ${
                           column.getIsSorted() && "hidden"
                         }`}
                         data-cy={`${column.id}-sorting`}
@@ -52,14 +52,14 @@ const Table = ({
                       <FaSortAlphaDown
                         onClick={column.getToggleSortingHandler()}
                         data-cy={`${column.id}-sorting-desc`}
-                        className="mx-2 hover:cursor-pointer text-white"
+                        className="mx-2 hover:cursor-pointer hover:opacity-50 text-white"
                       />
                     )}
                     {column.getIsSorted() === "desc" && (
                       <FaSortAlphaUp
                         onClick={column.getToggleSortingHandler()}
                         data-cy={`${column.columnDef.header}-sorting-asc`}
-                        className="mx-2 hover:cursor-pointer text-white"
+                        className="mx-2 hover:cursor-pointer hover:opacity-50 text-white"
                       />
                     )}
                   </div>


### PR DESCRIPTION
normal: 
![image](https://github.com/acm-ucr/hackathon-website/assets/102492968/5743bb97-0609-45b0-8214-9117386f923a)
![image](https://github.com/acm-ucr/hackathon-website/assets/102492968/08434a3a-cfc7-4981-b498-43b71d5eb9dc)
![image](https://github.com/acm-ucr/hackathon-website/assets/102492968/8f8e6125-feea-4e80-8d43-69ea5d979bb3)

hovered:
![image](https://github.com/acm-ucr/hackathon-website/assets/102492968/d835a264-eabd-4edd-b2c6-18175c9c7c4e)
![image](https://github.com/acm-ucr/hackathon-website/assets/102492968/3e4584a4-c342-43e4-a108-964a32734b7d)
![image](https://github.com/acm-ucr/hackathon-website/assets/102492968/a9993d7e-26b5-4f73-a21e-a03d51dab3fa)
