### PR TITLE
Fixed overflow issue with navbar tabs

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -32,11 +32,11 @@ const Navigation = () => {
         </div>
       </div>
       <div
-        className={`overflow-auto z-10 lg:flex lg:w-[12%] ${
+        className={`overflow-y-scroll z-10 lg:flex lg:w-[12%] ${
           expand ? "left-0 h-screen w-1/2 fixed pt-5" : `hidden`
         }`}
       >
-        <div className="overflow-auto bg-hackathon-blue-200 h-full flex flex-col justify-between items-center w-full">
+        <div className="overflow-y-scroll bg-hackathon-blue-200 h-full flex flex-col justify-between items-center w-full">
           <div className="hidden lg:flex items-center my-3">
             <Image
               src={LOGO}

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -32,11 +32,11 @@ const Navigation = () => {
         </div>
       </div>
       <div
-        className={`z-10 lg:flex lg:w-[12%] ${
+        className={`overflow-auto z-10 lg:flex lg:w-[12%] ${
           expand ? "left-0 h-screen w-1/2 fixed pt-5" : `hidden`
         }`}
       >
-        <div className="bg-hackathon-blue-200 h-full flex flex-col justify-between items-center w-full">
+        <div className="overflow-auto bg-hackathon-blue-200 h-full flex flex-col justify-between items-center w-full">
           <div className="hidden lg:flex items-center my-3">
             <Image
               src={LOGO}


### PR DESCRIPTION
![image](https://github.com/acm-ucr/hackathon-website/assets/102492968/a41fbe27-23a7-4d0a-b1b0-2995b65ba66b)
![image](https://github.com/acm-ucr/hackathon-website/assets/102492968/5d8e9fe8-2710-451d-9a15-bb8395ff679e)

Navbar is scrollable now, fixing overflowed tabs