### PR TITLE
Change end to date object

### DIFF
--- a/src/components/admin/services/Upload.jsx
+++ b/src/components/admin/services/Upload.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { RiAttachment2 } from "react-icons/ri";
 import { FaTimes } from "react-icons/fa";
 import toaster from "@/utils/toaster";

--- a/src/components/user/Countdown.jsx
+++ b/src/components/user/Countdown.jsx
@@ -2,8 +2,6 @@
 import { useState, useEffect } from "react";
 import data from "/src/data/Config.js";
 
-const endDate = data.end;
-
 const Digits = ({ value, unit }) => {
   return (
     <div className="flex flex-col items-center gap-4 last:hidden  sm:last:flex">
@@ -35,7 +33,7 @@ const Countdown = () => {
 
   useEffect(() => {
     const interval = setInterval(() => {
-      const timeLeft = endDate - new Date().getTime();
+      const timeLeft = data.end - new Date().getTime();
       timeLeft <= 0
         ? setCountdown({ days: 0, hours: 0, minutes: 0, seconds: 0 })
         : setCountdown({

--- a/src/components/user/Countdown.jsx
+++ b/src/components/user/Countdown.jsx
@@ -2,13 +2,7 @@
 import { useState, useEffect } from "react";
 import data from "/src/data/Config.js";
 
-const parts = data.end.split(" ");
-const sec = parts[3].split(":");
-const day = parseInt(parts[1]);
-const month = parts[0];
-const year = parseInt(parts[2]);
-const monthIndex = new Date(Date.parse(month + " 1, " + year)).getMonth() + 1;
-const endDate = new Date(year, monthIndex - 1, day, sec[0], sec[1], sec[2]);
+const endDate = data.end;
 
 const Digits = ({ value, unit }) => {
   return (

--- a/src/components/user/Countdown.jsx
+++ b/src/components/user/Countdown.jsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import data from "/src/data/Config.js";
 
 const parts = data.end.split(" ");

--- a/src/components/user/Tile.jsx
+++ b/src/components/user/Tile.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Link from "next/link";
 
 const Tile = ({ icon, text, link }) => {

--- a/src/data/Config.js
+++ b/src/data/Config.js
@@ -8,7 +8,7 @@ const data = {
   start_url: "/",
   year: "2024",
   date: "November 4th 2024",
-  end: "April 12th 2024 13:20:00",
+  end: new Date("2024-04-12T13:20:00"),
   packet: "",
   devpost: "https://devpost.com/",
   domain: "https://www.placeholder.com",


### PR DESCRIPTION
- changed end to be a Date object following the standard formatting for listing time
- removed countdown parsing as it is built in