### PR TITLE
Fixed user dashboard for mobile responsiveness

### DIFF
--- a/src/components/user/Dashboard.jsx
+++ b/src/components/user/Dashboard.jsx
@@ -24,7 +24,7 @@ const Dashboard = () => {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
         <div className="col-span-1 md:col-span-2">
           <Countdown />
-          <div className="md:flex gap-4">
+          <div className="flex flex-col md:flex-row gap-4 mt-4">
             <Tile icon={<BsQrCode />} text="Check In" link="/user/checkin" />
             <Tile
               icon={<LuParkingCircle />}


### PR DESCRIPTION
![image](https://github.com/acm-ucr/hackathon-website/assets/102492968/18997e00-a286-42b5-bf53-8d62495c2999)

Made it so the check-in and parking tiles stack vertically under the countdown in mobile viewports