### PR TITLE
Simplified "future marketing purposes" to "marketing purposes"

### DIFF
--- a/src/data/form/Admins.js
+++ b/src/data/form/Admins.js
@@ -102,7 +102,7 @@ export const FIELDS = {
     field: "requirements",
     options: [
       "I have read the MLH code of conduct and agree to the terms and conditions listed",
-      "I consent to photographs being taken and being used for future marketing purposes",
+      "I consent to photographs being taken and being used for marketing purposes",
       "I consent to providing a safe space for hackers to learn and grow their interests in computing",
       "I consent to following the provided guidelines and rules instructed by the organizing team",
       "I understand that failure to comply with guidelines or creating an unsafe space will result in my removal from the event",

--- a/src/data/form/Committees.js
+++ b/src/data/form/Committees.js
@@ -102,7 +102,7 @@ export const FIELDS = {
     field: "requirements",
     options: [
       "I have read the MLH code of conduct and agree to the terms and conditions listed",
-      "I consent to photographs being taken and being used for future marketing purposes",
+      "I consent to photographs being taken and being used for marketing purposes",
       "I consent to providing a safe space for hackers to learn and grow their interests in computing",
       "I consent to following the provided guidelines and rules instructed by the organizing team",
       "I understand that failure to comply with guidelines or creating an unsafe space will result in my removal from the event",

--- a/src/data/form/Interest.js
+++ b/src/data/form/Interest.js
@@ -37,7 +37,7 @@ export const FIELDS = {
     required: true,
     options: [
       "I have read the MLH code of conduct and agree to the terms and conditions listed",
-      "I consent to photographs being taken and being used for future marketing purposes",
+      "I consent to photographs being taken and being used for marketing purposes",
       "I consent to providing a safe space for hackers to learn and grow their interests in computing",
       "I consent to following the provided guidelines and rules instructed by the organizing team",
       "I understand that failure to comply with guidelines or creating an unsafe space will result in my removal from the event",

--- a/src/data/form/Judge.js
+++ b/src/data/form/Judge.js
@@ -104,7 +104,7 @@ export const FIELDS = {
     required: true,
     options: [
       "I have read the MLH code of conduct and agree to the terms and conditions listed",
-      "I consent to photographs being taken and being used for future marketing purposes",
+      "I consent to photographs being taken and being used for marketing purposes",
       "I consent to providing a safe space for hackers to learn and grow their interests in computing",
       "I consent to following the provided guidelines and rules instructed by the organizing team",
       "I understand that failure to comply with guidelines or creating an unsafe space will result in my removal from the event",

--- a/src/data/form/Leads.js
+++ b/src/data/form/Leads.js
@@ -159,7 +159,7 @@ export const FIELDS = {
     required: true,
     options: [
       "I have read the MLH code of conduct and agree to the terms and conditions listed",
-      "I consent to photographs being taken and being used for future marketing purposes",
+      "I consent to photographs being taken and being used for marketing purposes",
       "I consent to providing a safe space for hackers to learn and grow their interests in computing",
       "I consent to following the provided guidelines and rules instructed by the organizing team",
       "I understand that failure to comply with guidelines or creating an unsafe space will result in my removal from the event",

--- a/src/data/form/Mentors.js
+++ b/src/data/form/Mentors.js
@@ -115,7 +115,7 @@ export const FIELDS = {
     required: true,
     options: [
       "I have read the MLH code of conduct and agree to the terms and conditions listed",
-      "I consent to photographs being taken and being used for future marketing purposes",
+      "I consent to photographs being taken and being used for marketing purposes",
       "I consent to providing a safe space for hackers to learn and grow their interests in computing",
       "I consent to following the provided guidelines and rules instructed by the organizing team",
       "I understand that failure to comply with guidelines or creating an unsafe space will result in my removal from the event",

--- a/src/data/form/Panelists.js
+++ b/src/data/form/Panelists.js
@@ -112,7 +112,7 @@ export const FIELDS = {
     required: true,
     options: [
       "I have read the MLH code of conduct and agree to the terms and conditions listed",
-      "I consent to photographs being taken and being used for future marketing purposes",
+      "I consent to photographs being taken and being used for marketing purposes",
       "I consent to providing a safe space for hackers to learn and grow their interests in computing",
       "I consent to following the provided guidelines and rules instructed by the organizing team",
       "I understand that failure to comply with guidelines or creating an unsafe space will result in my removal from the event",

--- a/src/data/form/Participant.js
+++ b/src/data/form/Participant.js
@@ -138,7 +138,7 @@ export const FIELDS = {
     required: true,
     options: [
       "I have read the MLH code of conduct and agree to the terms and conditions listed",
-      "I consent to photographs being taken and being used for future marketing purposes",
+      "I consent to photographs being taken and being used for marketing purposes",
       "I consent to providing a safe space for hackers to learn and grow their interests in computing",
       "I consent to following the provided guidelines and rules instructed by the organizing team",
       "I understand that failure to comply with guidelines or creating an unsafe space will result in my removal from the event",

--- a/src/data/form/Sponsors.js
+++ b/src/data/form/Sponsors.js
@@ -95,7 +95,7 @@ export const FIELDS = {
     field: "requirements",
     options: [
       "I have read the MLH code of conduct and agree to the terms and conditions listed",
-      "I consent to photographs being taken and being used for future marketing purposes",
+      "I consent to photographs being taken and being used for marketing purposes",
       "I consent to providing a safe space for hackers to learn and grow their interests in computing",
       "I consent to following the provided guidelines and rules instructed by the organizing team",
       "I understand that failure to comply with guidelines or creating an unsafe space will result in my removal from the event",

--- a/src/data/form/Volunteers.js
+++ b/src/data/form/Volunteers.js
@@ -107,7 +107,7 @@ export const FIELDS = {
     required: true,
     options: [
       "I have read the MLH code of conduct and agree to the terms and conditions listed",
-      "I consent to photographs being taken and being used for future marketing purposes",
+      "I consent to photographs being taken and being used for marketing purposes",
       "I consent to providing a safe space for hackers to learn and grow their interests in computing",
       "I consent to following the provided guidelines and rules instructed by the organizing team",
       "I understand that failure to comply with guidelines or creating an unsafe space will result in my removal from the event",


### PR DESCRIPTION
I removed 'future' from the forms terms and conditions section so that it says marketing purposes instead.
