### PR TITLE
Refactor Radio

### DIFF
--- a/cypress/component/Radio.cy.jsx
+++ b/cypress/component/Radio.cy.jsx
@@ -3,17 +3,15 @@ import { GENDERS } from "@/data/form/Information";
 import { useState } from "react";
 
 describe("Radio", () => {
-  const handleClick = ([_, option], field, setter) => {
-    setter({
-      ...user,
-      [field]: option,
-    });
-  };
-
   it("renders text", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
-
+      const handleClick = (user, [_, optionName], field) => {
+        setUser({
+          ...user,
+          [field]: optionName,
+        });
+      };
       return (
         <Radio
           text="Gender"
@@ -22,7 +20,6 @@ describe("Radio", () => {
           user={user}
           editable={true}
           onChange={handleClick}
-          setUser={setUser}
         />
       );
     };
@@ -44,6 +41,13 @@ describe("Radio", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
 
+      const handleClick = (user, [_, optionName], field) => {
+        setUser({
+          ...user,
+          [field]: optionName,
+        });
+      };
+
       return (
         <Radio
           text="Gender"
@@ -52,7 +56,6 @@ describe("Radio", () => {
           user={user}
           editable={true}
           onChange={handleClick}
-          setUser={setUser}
         />
       );
     };
@@ -87,6 +90,12 @@ describe("Radio", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
 
+      const handleClick = (user, [_, optionName], field) => {
+        setUser({
+          ...user,
+          [field]: optionName,
+        });
+      };
       return (
         <Radio
           text="Gender"
@@ -95,7 +104,6 @@ describe("Radio", () => {
           user={user}
           editable={false}
           onChange={handleClick}
-          setFunc={setUser}
         />
       );
     };

--- a/cypress/component/Radio.cy.jsx
+++ b/cypress/component/Radio.cy.jsx
@@ -7,7 +7,7 @@ describe("Radio", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
       const handleClick = (option) => {
-        setUser({ ...user, [field]: option });
+        setUser({ ...user, [field]: option.toString().toLowerCase() });
       };
       return (
         <Radio
@@ -39,7 +39,7 @@ describe("Radio", () => {
       const [user, setUser] = useState({ name: "" });
 
       const handleClick = (option) => {
-        setUser({ ...user, [field]: option });
+        setUser({ ...user, [field]: option[1].toString().toLowerCase() });
       };
       return (
         <Radio
@@ -84,7 +84,7 @@ describe("Radio", () => {
       const [user, setUser] = useState({ name: "" });
 
       const handleClick = (option) => {
-        setUser({ ...user, [field]: option });
+        setUser({ ...user, [field]: option[1].toString().toLowerCase() });
       };
       return (
         <Radio

--- a/cypress/component/Radio.cy.jsx
+++ b/cypress/component/Radio.cy.jsx
@@ -3,18 +3,17 @@ import { GENDERS } from "@/data/form/Information";
 import { useState } from "react";
 
 describe("Radio", () => {
+  const handleClick = ([_, option], field, setter) => {
+    setter({
+      ...user,
+      [field]: option,
+    });
+  };
+
   it("renders text", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
-      const handleClick = ([key, option], field) => {
-        setUser({
-          ...user,
-          [field]:
-            field === "tier" || field === "affiliation" || field === "panelist"
-              ? key
-              : option,
-        });
-      };
+
       return (
         <Radio
           text="Gender"
@@ -23,6 +22,7 @@ describe("Radio", () => {
           user={user}
           editable={true}
           onChange={handleClick}
+          setUser={setUser}
         />
       );
     };
@@ -44,13 +44,6 @@ describe("Radio", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
 
-      const handleClick = ([_, option], field) => {
-        setUser({
-          ...user,
-          [field]: option,
-        });
-      };
-
       return (
         <Radio
           text="Gender"
@@ -59,6 +52,7 @@ describe("Radio", () => {
           user={user}
           editable={true}
           onChange={handleClick}
+          setUser={setUser}
         />
       );
     };
@@ -93,15 +87,6 @@ describe("Radio", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
 
-      const handleClick = ([key, option], field) => {
-        setUser({
-          ...user,
-          [field]:
-            field === "tier" || field === "affiliation" || field === "panelist"
-              ? key
-              : option,
-        });
-      };
       return (
         <Radio
           text="Gender"
@@ -110,6 +95,7 @@ describe("Radio", () => {
           user={user}
           editable={false}
           onChange={handleClick}
+          setFunc={setUser}
         />
       );
     };

--- a/cypress/component/Radio.cy.jsx
+++ b/cypress/component/Radio.cy.jsx
@@ -7,7 +7,7 @@ describe("Radio", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
       const handleClick = (option) => {
-        setUser({ ...user, [field]: option[1].toString() });
+        setUser({ ...user, ["gender"]: option[1] });
       };
       return (
         <Radio
@@ -39,7 +39,7 @@ describe("Radio", () => {
       const [user, setUser] = useState({ name: "" });
 
       const handleClick = (option) => {
-        setUser({ ...user, [field]: option[1].toString() });
+        setUser({ ...user, ["gender"]: option[1] });
       };
       return (
         <Radio
@@ -84,7 +84,7 @@ describe("Radio", () => {
       const [user, setUser] = useState({ name: "" });
 
       const handleClick = (option) => {
-        setUser({ ...user, [field]: option[1].toString() });
+        setUser({ ...user, ["gender"]: option[1] });
       };
       return (
         <Radio

--- a/cypress/component/Radio.cy.jsx
+++ b/cypress/component/Radio.cy.jsx
@@ -7,7 +7,7 @@ describe("Radio", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
       const handleClick = (option) => {
-        setUser({ ...user, [field]: option.toString().toLowerCase() });
+        setUser({ ...user, [field]: option[1].toString() });
       };
       return (
         <Radio
@@ -39,7 +39,7 @@ describe("Radio", () => {
       const [user, setUser] = useState({ name: "" });
 
       const handleClick = (option) => {
-        setUser({ ...user, [field]: option[1].toString().toLowerCase() });
+        setUser({ ...user, [field]: option[1].toString() });
       };
       return (
         <Radio
@@ -84,7 +84,7 @@ describe("Radio", () => {
       const [user, setUser] = useState({ name: "" });
 
       const handleClick = (option) => {
-        setUser({ ...user, [field]: option[1].toString().toLowerCase() });
+        setUser({ ...user, [field]: option[1].toString() });
       };
       return (
         <Radio

--- a/cypress/component/Radio.cy.jsx
+++ b/cypress/component/Radio.cy.jsx
@@ -44,13 +44,10 @@ describe("Radio", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
 
-      const handleClick = ([key, option], field) => {
+      const handleClick = ([_, option], field) => {
         setUser({
           ...user,
-          [field]:
-            field === "tier" || field === "affiliation" || field === "panelist"
-              ? key
-              : option,
+          [field]: option,
         });
       };
 

--- a/cypress/component/Radio.cy.jsx
+++ b/cypress/component/Radio.cy.jsx
@@ -6,14 +6,17 @@ describe("Radio", () => {
   it("renders text", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
+      const handleClick = (option) => {
+        setUser({ ...user, [field]: option });
+      };
       return (
         <Radio
           text="Gender"
           options={GENDERS}
           field="gender"
           user={user}
-          setUser={setUser}
           editable={true}
+          onChange={handleClick}
         />
       );
     };
@@ -34,14 +37,18 @@ describe("Radio", () => {
   it("selects options when editable", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
+
+      const handleClick = (option) => {
+        setUser({ ...user, [field]: option });
+      };
       return (
         <Radio
           text="Gender"
           options={GENDERS}
           field="gender"
           user={user}
-          setUser={setUser}
           editable={true}
+          onChange={handleClick}
         />
       );
     };
@@ -75,14 +82,18 @@ describe("Radio", () => {
   it("cannot select options when uneditable", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
+
+      const handleClick = (option) => {
+        setUser({ ...user, [field]: option });
+      };
       return (
         <Radio
           text="Gender"
           options={GENDERS}
           field="gender"
           user={user}
-          setUser={setUser}
           editable={false}
+          onChange={handleClick}
         />
       );
     };

--- a/cypress/component/Radio.cy.jsx
+++ b/cypress/component/Radio.cy.jsx
@@ -6,8 +6,8 @@ describe("Radio", () => {
   it("renders text", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
-      const handleClick = (user, [_, optionName], field) => {
-        setUser({
+      const handleClick = (user, [_, optionName], field, setter) => {
+        setter({
           ...user,
           [field]: optionName,
         });
@@ -20,6 +20,7 @@ describe("Radio", () => {
           user={user}
           editable={true}
           onChange={handleClick}
+          setUser={setUser}
         />
       );
     };
@@ -41,8 +42,8 @@ describe("Radio", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
 
-      const handleClick = (user, [_, optionName], field) => {
-        setUser({
+      const handleClick = (user, [_, optionName], field, setter) => {
+        setter({
           ...user,
           [field]: optionName,
         });
@@ -56,6 +57,7 @@ describe("Radio", () => {
           user={user}
           editable={true}
           onChange={handleClick}
+          setUser={setUser}
         />
       );
     };
@@ -90,8 +92,8 @@ describe("Radio", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
 
-      const handleClick = (user, [_, optionName], field) => {
-        setUser({
+      const handleClick = (user, [_, optionName], field, setter) => {
+        setter({
           ...user,
           [field]: optionName,
         });
@@ -104,6 +106,7 @@ describe("Radio", () => {
           user={user}
           editable={false}
           onChange={handleClick}
+          setUser={setUser}
         />
       );
     };

--- a/cypress/component/Radio.cy.jsx
+++ b/cypress/component/Radio.cy.jsx
@@ -6,8 +6,14 @@ describe("Radio", () => {
   it("renders text", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
-      const handleClick = (option) => {
-        setUser({ ...user, ["gender"]: option[1] });
+      const handleClick = ([key, option], field) => {
+        setUser({
+          ...user,
+          [field]:
+            field === "tier" || field === "affiliation" || field === "panelist"
+              ? key
+              : option,
+        });
       };
       return (
         <Radio
@@ -38,9 +44,16 @@ describe("Radio", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
 
-      const handleClick = (option) => {
-        setUser({ ...user, ["gender"]: option[1] });
+      const handleClick = ([key, option], field) => {
+        setUser({
+          ...user,
+          [field]:
+            field === "tier" || field === "affiliation" || field === "panelist"
+              ? key
+              : option,
+        });
       };
+
       return (
         <Radio
           text="Gender"
@@ -83,8 +96,14 @@ describe("Radio", () => {
     const Parent = () => {
       const [user, setUser] = useState({ name: "" });
 
-      const handleClick = (option) => {
-        setUser({ ...user, ["gender"]: option[1] });
+      const handleClick = ([key, option], field) => {
+        setUser({
+          ...user,
+          [field]:
+            field === "tier" || field === "affiliation" || field === "panelist"
+              ? key
+              : option,
+        });
       };
       return (
         <Radio

--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -25,7 +25,7 @@ const Radio = ({
               data-cy={`radio-${option[1].toString()}`}
               className="flex items-center whitespace-nowrap hover:cursor-pointer"
               key={index}
-              onChange={() => onChange(option)}
+              onChange={() => onChange(option, field)}
             >
               <div className="rounded-full w-4 border-black border aspect-square bg-transparent p-0.5 mr-1">
                 <div

--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -1,19 +1,12 @@
 const Radio = ({
-  text,
-  field,
-  options,
-  user,
-  setUser,
-  editable = true,
-  required,
+    text,
+    field,
+    options,
+    user,
+    editable = true,
+    required,
+    onChange,
 }) => {
-  const handleClick = (optionKey, option) => {
-    if (field === "tier" || field === "affiliation" || field === "panelist") {
-      setUser({ ...user, [field]: optionKey });
-    } else {
-      setUser({ ...user, [field]: option });
-    }
-  };
 
   return (
     <div data-cy={`radio-${field}`} className="flex flex-col">
@@ -28,18 +21,18 @@ const Radio = ({
       )}
       {editable && (
         <div className="grid grid-cols-2 md:grid-cols-3 w-full">
-          {Object.entries(options).map(([optionKey, option], index) => (
+          {Object.entries(options).map(( option, index) => (
             <div
               data-cy={`radio-${option}`}
               className="flex items-center whitespace-nowrap hover:cursor-pointer"
               key={index}
-              onClick={() => handleClick(optionKey, option)}
+              onChange={() => onChange(option.toLowerCase())}
             >
               <div className="rounded-full w-4 border-black border aspect-square bg-transparent p-0.5 mr-1">
                 <div
                   data-cy={`radio-button-${option}`}
                   className={`rounded-full w-full aspect-square duration-100 ${
-                    user[field] === option || user[field] === optionKey
+                    user[field] === option.toLowerCase()
                       ? "bg-hackathon-green-300"
                       : "bg-transparent"
                   }`}

--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -25,13 +25,13 @@ const Radio = ({
               data-cy={`radio-${option}`}
               className="flex items-center whitespace-nowrap hover:cursor-pointer"
               key={index}
-              onChange={() => onChange(option.toLowerCase())}
+              onChange={() => onChange(option.toString().toLowerCase())}
             >
               <div className="rounded-full w-4 border-black border aspect-square bg-transparent p-0.5 mr-1">
                 <div
                   data-cy={`radio-button-${option}`}
                   className={`rounded-full w-full aspect-square duration-100 ${
-                    user[field] === option.toLowerCase()
+                    user[field] == option.toString().toLowerCase()
                       ? "bg-hackathon-green-300"
                       : "bg-transparent"
                   }`}

--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -31,13 +31,13 @@ const Radio = ({
                 <div
                   data-cy={`radio-button-${option[1].toString().toLowerCase()}`}
                   className={`rounded-full w-full aspect-square duration-100 ${
-                    user[field] === option[1].toString().toLowerCase()
+                    user[field] === option[1].toString()
                       ? "bg-hackathon-green-300"
                       : "bg-transparent"
                   }`}
                 />
               </div>
-              {option[1].toString().toLowerCase()}
+              {option[1].toString()}
             </div>
           ))}
         </div>

--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -31,7 +31,7 @@ const Radio = ({
                 <div
                   data-cy={`radio-button-${option[1].toString().toLowerCase()}`}
                   className={`rounded-full w-full aspect-square duration-100 ${
-                    user[field] === option[1].tosString().toLowerCase()
+                    user[field] === option[1].toString().toLowerCase()
                       ? "bg-hackathon-green-300"
                       : "bg-transparent"
                   }`}

--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -25,19 +25,19 @@ const Radio = ({
               data-cy={`radio-${option}`}
               className="flex items-center whitespace-nowrap hover:cursor-pointer"
               key={index}
-              onChange={() => onChange(option.toString().toLowerCase())}
+              onChange={() => onChange(option)}
             >
               <div className="rounded-full w-4 border-black border aspect-square bg-transparent p-0.5 mr-1">
                 <div
-                  data-cy={`radio-button-${option}`}
+                  data-cy={`radio-button-${option[1].toString().toLowerCase()}`}
                   className={`rounded-full w-full aspect-square duration-100 ${
-                    user[field] == option.toString().toLowerCase()
+                    user[field] === option[1].tosString().toLowerCase()
                       ? "bg-hackathon-green-300"
                       : "bg-transparent"
                   }`}
                 />
               </div>
-              {option}
+              {option[1].toString().toLowerCase()}
             </div>
           ))}
         </div>

--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -22,7 +22,7 @@ const Radio = ({
         <div className="grid grid-cols-2 md:grid-cols-3 w-full">
           {Object.entries(options).map((option, index) => (
             <div
-              data-cy={`radio-${option}`}
+              data-cy={`radio-${option[1].toString()}`}
               className="flex items-center whitespace-nowrap hover:cursor-pointer"
               key={index}
               onChange={() => onChange(option)}

--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -29,7 +29,7 @@ const Radio = ({
             >
               <div className="rounded-full w-4 border-black border aspect-square bg-transparent p-0.5 mr-1">
                 <div
-                  data-cy={`radio-button-${option[1].toString().toLowerCase()}`}
+                  data-cy={`radio-button-${option[1].toString()}`}
                   className={`rounded-full w-full aspect-square duration-100 ${
                     user[field] === option[1].toString()
                       ? "bg-hackathon-green-300"

--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -1,13 +1,12 @@
 const Radio = ({
-    text,
-    field,
-    options,
-    user,
-    editable = true,
-    required,
-    onChange,
+  text,
+  field,
+  options,
+  user,
+  editable = true,
+  required,
+  onChange,
 }) => {
-
   return (
     <div data-cy={`radio-${field}`} className="flex flex-col">
       <p className="mb-1 font-semibold">
@@ -21,7 +20,7 @@ const Radio = ({
       )}
       {editable && (
         <div className="grid grid-cols-2 md:grid-cols-3 w-full">
-          {Object.entries(options).map(( option, index) => (
+          {Object.entries(options).map((option, index) => (
             <div
               data-cy={`radio-${option}`}
               className="flex items-center whitespace-nowrap hover:cursor-pointer"

--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -6,6 +6,7 @@ const Radio = ({
   editable = true,
   required,
   onChange,
+  setUser,
 }) => {
   return (
     <div data-cy={`radio-${field}`} className="flex flex-col">
@@ -25,7 +26,7 @@ const Radio = ({
               data-cy={`radio-${option[1]}`}
               className="flex items-center whitespace-nowrap hover:cursor-pointer"
               key={index}
-              onChange={() => onChange(user, option, field)}
+              onChange={() => onChange(user, option, field, setUser)}
             >
               <div className="rounded-full w-4 border-black border aspect-square bg-transparent p-0.5 mr-1">
                 <div

--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -31,7 +31,7 @@ const Radio = ({
                 <div
                   data-cy={`radio-button-${option[1]}`}
                   className={`rounded-full w-full aspect-square duration-100 ${
-                    user[field] === option[4]
+                    user[field] === option[1]
                       ? "bg-hackathon-green-300"
                       : "bg-transparent"
                   }`}

--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -22,22 +22,22 @@ const Radio = ({
         <div className="grid grid-cols-2 md:grid-cols-3 w-full">
           {Object.entries(options).map((option, index) => (
             <div
-              data-cy={`radio-${option[1].toString()}`}
+              data-cy={`radio-${option[1]}`}
               className="flex items-center whitespace-nowrap hover:cursor-pointer"
               key={index}
               onChange={() => onChange(option, field)}
             >
               <div className="rounded-full w-4 border-black border aspect-square bg-transparent p-0.5 mr-1">
                 <div
-                  data-cy={`radio-button-${option[1].toString()}`}
+                  data-cy={`radio-button-${option[1]}`}
                   className={`rounded-full w-full aspect-square duration-100 ${
-                    user[field] === option[1] || user[field] === option[0]
+                    user[field] === option[4]
                       ? "bg-hackathon-green-300"
                       : "bg-transparent"
                   }`}
                 />
               </div>
-              {option[1].toString()}
+              {option[1]}
             </div>
           ))}
         </div>

--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -6,6 +6,7 @@ const Radio = ({
   editable = true,
   required,
   onChange,
+  setUser,
 }) => {
   return (
     <div data-cy={`radio-${field}`} className="flex flex-col">
@@ -25,13 +26,18 @@ const Radio = ({
               data-cy={`radio-${option[1]}`}
               className="flex items-center whitespace-nowrap hover:cursor-pointer"
               key={index}
-              onChange={() => onChange(option, field)}
+              onChange={() => onChange(option, field, setUser)}
             >
               <div className="rounded-full w-4 border-black border aspect-square bg-transparent p-0.5 mr-1">
                 <div
                   data-cy={`radio-button-${option[1]}`}
                   className={`rounded-full w-full aspect-square duration-100 ${
-                    user[field] === option[1]
+                    user[field].toString().toLowerCase() ===
+                      option[1].toString().toLowerCase() ||
+                    user[field].toString().toLowerCase() ===
+                      option[0].toString().toLowerCase() ||
+                    user[field] === option[1] ||
+                    user[field] === option[0]
                       ? "bg-hackathon-green-300"
                       : "bg-transparent"
                   }`}

--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -31,7 +31,7 @@ const Radio = ({
                 <div
                   data-cy={`radio-button-${option[1].toString()}`}
                   className={`rounded-full w-full aspect-square duration-100 ${
-                    user[field] === option[1].toString()
+                    user[field] === option[1] || user[field] === option[0]
                       ? "bg-hackathon-green-300"
                       : "bg-transparent"
                   }`}

--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -6,7 +6,6 @@ const Radio = ({
   editable = true,
   required,
   onChange,
-  setUser,
 }) => {
   return (
     <div data-cy={`radio-${field}`} className="flex flex-col">
@@ -26,18 +25,13 @@ const Radio = ({
               data-cy={`radio-${option[1]}`}
               className="flex items-center whitespace-nowrap hover:cursor-pointer"
               key={index}
-              onChange={() => onChange(option, field, setUser)}
+              onChange={() => onChange(user, option, field)}
             >
               <div className="rounded-full w-4 border-black border aspect-square bg-transparent p-0.5 mr-1">
                 <div
                   data-cy={`radio-button-${option[1]}`}
                   className={`rounded-full w-full aspect-square duration-100 ${
-                    user[field].toString().toLowerCase() ===
-                      option[1].toString().toLowerCase() ||
-                    user[field].toString().toLowerCase() ===
-                      option[0].toString().toLowerCase() ||
-                    user[field] === option[1] ||
-                    user[field] === option[0]
+                    user[field] === option[1]
                       ? "bg-hackathon-green-300"
                       : "bg-transparent"
                   }`}


### PR DESCRIPTION
Added an onChange property which will accept function references; removed the optionKey property;

```js
const Radio = ({
  text,
  field,
  options,
  user,
  editable = true,
  required,
  onChange,
}) => {
  return (
    <div data-cy={`radio-${field}`} className="flex flex-col">
      <p className="mb-1 font-semibold">
        {text}
        {required && <span className="text-red-500">*</span>}
      </p>
      {!editable && (
        <div data-cy={`radio-${field}-default`} className="pl-3">
          {user[field]}
        </div>
      )}
      {editable && (
        <div className="grid grid-cols-2 md:grid-cols-3 w-full">
          {Object.entries(options).map((option, index) => (
            <div
              data-cy={`radio-${option}`}
              className="flex items-center whitespace-nowrap hover:cursor-pointer"
              key={index}
              onChange={() => onChange(option.toLowerCase())}
            >
              <div className="rounded-full w-4 border-black border aspect-square bg-transparent p-0.5 mr-1">
                <div
                  data-cy={`radio-button-${option}`}
                  className={`rounded-full w-full aspect-square duration-100 ${
                    user[field] === option.toLowerCase()
                      ? "bg-hackathon-green-300"
                      : "bg-transparent"
                  }`}
                />
              </div>
              {option}
            </div>
          ))}
        </div>
      )}
    </div>
  );
};
```
```js
const handleClick = (option) => {
        setUser({ ...user, [field]: option });
};
```